### PR TITLE
Add command line parsing for rerouting

### DIFF
--- a/configuration/configure.jl
+++ b/configuration/configure.jl
@@ -92,6 +92,7 @@ pad_schedule::Bool    = parsed_args["pad_schedule"];
 select_line::String   = parsed_args["select_line"];
 cut_day::Bool         = parsed_args["cut_day"];
 skip::Bool            = parsed_args["skip"];
+reroute::Bool         = parsed_args["reroute"]
 
 @enum TrackNr TWOTRACKS=0 ONETRACK=1 UNASSIGNED=-1; # kind of block (monorail, doublerail)
 
@@ -1086,11 +1087,12 @@ function composeTimetable(padfile::String, xmlfile::String, stationfile::String,
         end
 
         # Rerouting to Pottendorfer Linie from Sudbahn
-        #reroute_trainids = ["RJ_130"]
-        for trainid in readlines(TRAINS_TO_REROUTE_FILE)
-            @info "Rerouting $(trainid) to Pottendorfer Linie.."
-            reroute_sudbahn_to_pottendorfer!(dfout, trainid=trainid)
-            @info "Rerouting of $(trainid) done!"
+        if reroute
+            for trainid in readlines(TRAINS_TO_REROUTE_FILE)
+                @info "Rerouting $(trainid) to Pottendorfer Linie.."
+                reroute_sudbahn_to_pottendorfer!(dfout, trainid=trainid)
+                @info "Rerouting of $(trainid) done!"
+            end
         end
 
         passingStation!(dfout,dfsta);

--- a/configuration/exo_delays.jl
+++ b/configuration/exo_delays.jl
@@ -48,8 +48,8 @@ function SampleExoDelays(
     @info "\tLoading data."
 
     dfn=DataFrame(CSV.File(fileNdelay, select=[:number]));
-    dftbl=DataFrame(CSV.File(fileTimetable, select=[:train])); # Or Mon, Tue, ... Or timetable
-    trains=unique(dftbl.train);
+    dftbl=DataFrame(CSV.File(fileTimetable, select=[:trainid])); # Or Mon, Tue, ... Or timetable
+    trains=unique(dftbl.trainid);
 
     df=DataFrame(CSV.File(fileDelayList));
     

--- a/configuration/parser.jl
+++ b/configuration/parser.jl
@@ -70,6 +70,10 @@ function parse_commandline()
         #     arg_type = Int
         #     default = 0
 
+        "--reroute"
+            help = "Reroute trains in the file \"configuration/data/trains-to-reroute-to-Pottendorfer.csv\" to Pottendorfer Linie from Sudbahn"
+            action = :store_true
+
     end
 
     return parse_args(s)


### PR DESCRIPTION
Rerouting can now be enabled using --reroute while running configure.jl